### PR TITLE
Fix gzip close

### DIFF
--- a/lib/paperclip/processors/gzip.rb
+++ b/lib/paperclip/processors/gzip.rb
@@ -13,16 +13,11 @@ module Paperclip
         strategy    = @gzip_options[:strategy]
 
         dst = create_tempfile
-        begin
-          gz = Zlib::GzipWriter.new(dst, level, strategy)
+        Zlib::GzipWriter.open(dst, level, strategy) do |gz|
           while chunk = @file.read(16 * 1024) do
             gz.write chunk
           end
-        rescue ::Exception => e
-          gz.close rescue nil
-          raise e
         end
-        gz.close
         @file.rewind
         dst.open
 

--- a/spec/paperclip/processors/gzip_spec.rb
+++ b/spec/paperclip/processors/gzip_spec.rb
@@ -26,37 +26,6 @@ describe Paperclip::Processors::Gzip do
         let(:options) { {gzip_options: {level: Zlib::BEST_COMPRESSION}} }
         include_examples "deflate"
       end
-      context "gzip failed to close" do
-        before do
-          @error = RuntimeError.new "error"
-          @writer = {}
-          allow(Zlib::GzipWriter).to receive(:new).and_return @writer
-          allow(@writer).to receive(:write).and_return nil
-        end
-
-        it "raises an error to close" do
-          expect(@writer).to receive(:close).and_raise @error
-          expect {
-            subject.make
-          }.to raise_error @error
-        end
-      end
-      context "gzip failed to write" do
-        before do
-          @error1 = RuntimeError.new "error1"
-          @error2 = RuntimeError.new "error2"
-          @writer = {}
-          allow(Zlib::GzipWriter).to receive(:new).and_return @writer
-          allow(@writer).to receive(:write).and_raise @error1
-        end
-
-        it "does not raise an error to close" do
-          expect(@writer).to receive(:close).and_raise @error2
-          expect {
-            subject.make
-          }.to raise_error @error1
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
Trying to fix weird `Zlib::DataError`. My Resque worker emitted the following log.

```
zlib(finalizer): Zlib::GzipWriter object must be closed explicitly.
zlib(finalizer): the stream state was inconsistent.
```